### PR TITLE
Address Issues that can be addressed via README changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,19 @@ This is a _modified_ [Crockford encoding](https://www.crockford.com/base32.html)
 - Each character corresponds to 5 bits of input.
 - Lexicographic order of strings is preserved through Base 32 encoding.
 
+### `decimal -> base32` Table
+
+| 00xxx | 01xxx | 10xxx | 11xxx |
+| --- | --- | --- | --- |
+| 0 -> 0 | 8 -> 8 | 16 -> g | 24 -> r |
+| 1 -> 1 | 9 -> 9 | 17 -> h | 25 -> t |
+| 2 -> 2 | 10 -> a | 18 -> j | 26 -> u  |
+| 3 -> 3 | 11 -> b | 19 -> k | 27 -> v |
+| 4 -> 4 | 12 -> c | 20 -> m | 28 -> w |
+| 5 -> 5 | 13 -> d | 21 -> n | 29 -> x |
+| 6 -> 6 | 14 -> e | 22 -> p | 30 -> y |
+| 7 -> 7 | 15 -> f | 23 -> q | 31 -> z |
+
 ## Formalia
 
 Under MIT License.

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ base32 -s test/*
 
 There are about (128 choose 32) different specifications of something called "Base 32" - see [Wikipedia](http://en.wikipedia.org/wiki/Base_32) for some of them.
 
-This is just one that should be simple, less error-prone, and streamable (for [Node](http://nodejs.org)).
+This is a _modified_ [Crockford encoding](https://www.crockford.com/base32.html) that should be simple, less error-prone, and streamable (for [Node](http://nodejs.org)).
 
 ## Minispec
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Base 32 is between hexadecimal notation and Base 64 encoding. It's intended to b
 
 One of the primary purposes is to have aesthetically pleasing SHA1 hashes. Compare:
 
- - Hex: `17O57684bea1f9331418b633a8f373119d765fd4`
+ - Hex: `17057684bea1f9331418b633a8f373119d765fd4`
  - B64: `xE_ptB5SeclHm8JEsD0-ST1mTBM`
  - B32: `2w2qd15ym7wk650rprtuh4vk26eqcqym`
 

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ This is a _modified_ [Crockford encoding](https://www.crockford.com/base32.html)
   - S -> 5
 
 - When *decoding*, capital letters are converted to lowercase and the "ambiguous" letters mentioned above converted to their numeric counterparts.
-- Each character corresponds to 5 bits of input.
+- Each character corresponds to 5 bits of input, tail-padded with 0s where necessary.
 - Lexicographic order of strings is preserved through Base 32 encoding.
 
 ### `decimal -> base32` Table


### PR DESCRIPTION
- Issue #12: just swapping out "O" for "0" to make it a valid hex string
- Issue #23: making it clear that this is a similar encoding to Crockford, but is not the same
- Issue #25: forgoing all ambiguity on what the encoding might be, by explicitly documenting the encoding table (open to aesthetic changes)
- Added the detail that ending batches of < 5 bits are zero-padded, just as a bonus